### PR TITLE
Fix walls from lower floors blending through on wallsonly mode

### DIFF
--- a/src/map/svgrender.ts
+++ b/src/map/svgrender.ts
@@ -160,6 +160,9 @@ export async function svgfloor(engine: EngineCache, grid: TileGridSource, locs: 
 			if (!tile || tile?.effectiveLevel != loc.effectiveLevel) { break; }
 			if (tile.effectiveLevel == maplevel && (getOverlayColor(tile) != transparent || tile.underlayVisible)) { occluded = true; }
 		}
+
+		if (wallsonly && loc.effectiveLevel != maplevel) { occluded = true; }
+
 		if (loc.location.mapscene == undefined) {
 			if (drawwalls && !occluded) {
 				if (loc.type == 0) {


### PR DESCRIPTION
This patch fixes the issue where walls from lower floors blend through to upper floors when creating the svg in wallsonly-mode.
This is a conservative fix to fix it only in wallsonly-mode to not inadvertently break intended behaviour for the classic map. This way, it will only affect the sattelite view with overlayed walls.

As an example, Falador castle floor 2 (chunk 46,52).

Before:
![test2](https://github.com/skillbert/rsmv/assets/14322950/601d0ff1-f316-4699-addf-a8015d91e1e2)

After:
![test2](https://github.com/skillbert/rsmv/assets/14322950/dc115214-cf41-4399-8493-0d8b0923ea9b)