### PR TITLE
fix icon camera by adjusting aspect ratio

### DIFF
--- a/src/viewer/scenenodes.tsx
+++ b/src/viewer/scenenodes.tsx
@@ -1468,6 +1468,7 @@ function ItemCameraMode({ ctx, meta, centery }: { ctx: UIContextReady, meta?: it
 
 	cam.position.copy(pos);
 	cam.quaternion.copy(rot);
+	cam.aspect = ctx.renderer.getCanvas().width / ctx.renderer.getCanvas().height;
 	cam.updateProjectionMatrix();
 	cam.updateMatrixWorld(true);
 

--- a/src/viewer/threejsrender.ts
+++ b/src/viewer/threejsrender.ts
@@ -163,6 +163,9 @@ export class ThreeJsRenderer extends TypedEmitter<ThreeJsRendererEvents>{
 		this.sceneElementsChanged();
 	}
 
+	getCanvas() {
+		return this.canvas;
+	}
 
 	getStandardCamera() {
 		return this.camera as any;


### PR DESCRIPTION
This adjustment ensures that the Icon Camera mode for items retains the correct aspect ratio and doesn't get stretched according to the canvas size (=screen size).

Fix borrowed from https://stackoverflow.com/questions/70350200/gltf-inside-canvas-threejs-is-stretched