### PR TITLE
new object opcodes for POH rework

### DIFF
--- a/generated/objects.d.ts
+++ b/generated/objects.d.ts
@@ -132,6 +132,9 @@ export type objects = {
 		unknown_2: number,
 	}[] | null
 	mapFunction?: number | null
+	unknown_6C?: true | null
+	unknown_6D?: true | null
+	unknown_6E?: true | null
 	unknown_71?: number | null
 	members_action_1?: string | null
 	members_action_2?: string | null
@@ -238,6 +241,7 @@ export type objects = {
 		}[] | null,
 		default: number,
 	} | null
+	unknown_CE?: number[] | null
 	extra?: {
 		prop: number,
 		intvalue: number | null,

--- a/src/opcodes/objects.jsonc
+++ b/src/opcodes/objects.jsonc
@@ -99,6 +99,9 @@
 	"0x69": { "name":                      "invertMapScene", "read": "true" },
 	"0x6A": { "name":                          "headModels", "read": [ "array", ["struct", ["model", "varuint"], ["unknown_2", "unsigned byte"]] ] },
 	"0x6B": { "name":                         "mapFunction", "read": "unsigned short" },
+	"0x6C": { "name":                          "unknown_6C", "read": "true" },
+	"0x6D": { "name":                          "unknown_6D", "read": "true" },
+	"0x6E": { "name":                          "unknown_6E", "read": "true" },
 	"0x71": { "name":                          "unknown_71", "read": "unsigned byte" },
 	"0x96": { "name":                    "members_action_1", "read": "string" },
 	"0x97": { "name":                    "members_action_2", "read": "string" },
@@ -138,5 +141,6 @@
 	"0xCB": { "name":						   "unknown_CB", "read": "true" },
 	"0xCC": { "name":						   "unknown_CC", "read": ["array","ubyte",["buffer",27,"hex"]] },
 	"0xCD": { "name":						   "unknown_CD", "read": "modelmorphs" },
+	"0xCE": { "name":                          "unknown_CE", "read": [ "array", "ushort", "ubyte" ] },
 	"0xF9": { "name":                               "extra", "read": "extrasmap" }
 }


### PR DESCRIPTION
Add support for new object opcodes 108, 109, 110, 206 seen with the latest POH rework. ImRubic came up with this info:

> 206 is an array, where the count is read as a Ushort, and values as a Byte.
> 
> 108 = Roofs
> 109 = Floors
> 110 = Doors/Walls
> 
> 206 = Floor info?

Wasn't sure on the confidence of the naming or what they actually do, so I've left them named as "unknown_XX".